### PR TITLE
Remove unnecessary component scan annotations

### DIFF
--- a/src/main/java/com/atomist/demo/SpringoneApplication.java
+++ b/src/main/java/com/atomist/demo/SpringoneApplication.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@ComponentScan
 @SpringBootApplication
 public class SpringoneApplication {
 


### PR DESCRIPTION
`@ComponentScan` annotations are not necessary on `@SpringBootApplication` classes as they are inherited